### PR TITLE
Added gruposantander on .npmrc

### DIFF
--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,2 +1,2 @@
-@gruposantander:registry=https://npm.pkg.github.com/
+@gruposantander:registry=https://npm.pkg.github.com/gruposantander
 //npm.pkg.github.com/:_authToken=$TOKEN


### PR DESCRIPTION
This prevents errors like "Your request could not be authenticated by the GitHub Packages service." when using npm install